### PR TITLE
Switch deployment to AWS: App Runner and Kubernetes manifest updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,9 +13,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: akhileshns/heroku-deploy@v3.12.12
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
-          heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
-          heroku_email: ${{ secrets.HEROKU_EMAIL }}
-          usedocker: true
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push Docker image
+        env:
+          IMAGE_TAG: ${{ github.sha }}
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+        run: |
+          IMAGE_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPOSITORY:$IMAGE_TAG
+          docker build -t $IMAGE_URI .
+          docker push $IMAGE_URI
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_ENV
+
+      - name: Deploy to AWS App Runner
+        uses: awslabs/aws-app-runner-deploy@v1
+        with:
+          service-name: berhan-erp
+          image: ${{ env.IMAGE_URI }}
+          region: ${{ secrets.AWS_REGION }}
+          wait-for-service-stability: true

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: erp-berhan:1.0.0
+         iimage: 123456789012.dkr.ecr.eu-west-1.amazonaws.com/erp-berhan:latest
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true
@@ -23,7 +23,7 @@ spec:
               type: RuntimeDefault
           ports:
             - name: http
-              containerPort: 8000
+              ccontainerPort: 8080
           env:
             - name: DATABASE_URL
               valueFrom:
@@ -47,12 +47,12 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 8000
+         port: 8080
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8000
+         port: 8080
             initialDelaySeconds: 30
             periodSeconds: 20
       affinity:


### PR DESCRIPTION
This pull request replaces the existing Heroku deployment with AWS App Runner and ECR. The GitHub Actions workflow `.github/workflows/deploy.yml` now configures AWS credentials via OIDC, logs into ECR, builds and pushes the Docker image, and deploys to App Runner using the `awslabs/aws-app-runner-deploy` action.

The Kubernetes deployment manifest (`deploy/k8s/deployment.yaml`) has been updated to use the ECR image and to expose port 8080 for compatibility with the App Runner service. Readiness and liveness probe ports were updated accordingly.

These changes correspond to the AWS configuration (service name `berhan-erp`, runtime Python 3.11, PORT 8080) provided in the attached App Runner configuration.